### PR TITLE
fixed the typo in the cloning instructions in the readme #65

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Have an eye for the best project :eyes:
 
 
 ## Installation
-* `git clone https://github.com/mexili/incog-ly`
+* `git clone https://github.com/mexili/incogly`
 * `cd incogly`
 * `yarn && node server.js`
 


### PR DESCRIPTION
### What is the change?
Hey I was just cloning the project and installing it from the instructions provided. I guess there is a small typo in the 'git clone' command in the documentation. Noticed an error. Issue #65


### What does it fix/add?
Fixed the typo in the readme instructions to clone and install the project


